### PR TITLE
Convert from Moq to NSubstitute

### DIFF
--- a/test/Autofac.Integration.SignalR.Test/Autofac.Integration.SignalR.Test.csproj
+++ b/test/Autofac.Integration.SignalR.Test/Autofac.Integration.SignalR.Test.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="Moq" />
+    <Using Include="NSubstitute" />
     <Using Include="Xunit" />
   </ItemGroup>
 
@@ -38,7 +38,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/Autofac.Integration.SignalR.Test/AutofacDependencyResolverFixture.cs
+++ b/test/Autofac.Integration.SignalR.Test/AutofacDependencyResolverFixture.cs
@@ -99,7 +99,7 @@ public class AutofacDependencyResolverFixture
     public void CanOverrideDefaultServices()
     {
         var builder = new ContainerBuilder();
-        var messageBus = new Mock<IMessageBus>().Object;
+        var messageBus = Substitute.For<IMessageBus>();
         builder.RegisterInstance(messageBus);
         var resolver = new AutofacDependencyResolver(builder.Build());
 


### PR DESCRIPTION
## Summary
- Replace Moq with NSubstitute 5.3.0
- Convert single `Mock<IMessageBus>().Object` usage to `Substitute.For<IMessageBus>()`
- Part of cross-repo effort to standardize on NSubstitute

## Test plan
- [ ] CI build passes (net472 project, cannot build locally on macOS)